### PR TITLE
[WiP]: Initial DDlog scaffolding in controller

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ovs"]
 	path = ovs
-	url = https://github.com/openvswitch/ovs.git
+	url = https://github.com/amytai/ovs.git

--- a/controller/automake.mk
+++ b/controller/automake.mk
@@ -6,6 +6,8 @@ controller_ovn_controller_SOURCES = \
 	controller/binding.h \
 	controller/chassis.c \
 	controller/chassis.h \
+	controller/ddlog.c \
+	controller/ddlog.h \
 	controller/encaps.c \
 	controller/encaps.h \
 	controller/ha-chassis.c \

--- a/controller/automake.mk
+++ b/controller/automake.mk
@@ -49,7 +49,9 @@ EXTRA_DIST += \
 	$(controller_ddlog_sources)
 
 controller_ddlog_sources = \
-	controller/ovn_controller.dl
+	controller/ovn_controller.dl \
+    controller/helper.dl \
+    controller/helper.rs
 controller_ddlog_nodist_sources = \
 	controller/OVN_Southbound.dl \
 	controller/OVS.dl

--- a/controller/ddlog.c
+++ b/controller/ddlog.c
@@ -1,0 +1,46 @@
+#include <config.h>
+
+#include "openvswitch/vlog.h"
+#include "ddlog.h"
+
+VLOG_DEFINE_THIS_MODULE(controller_ddlog);
+
+bool print_records_callback(uintptr_t arg, const ddlog_record *rec, ssize_t weight)
+{
+    (void) arg;
+    (void) weight;
+
+    char *record_as_string = ddlog_dump_record(rec);
+    if (record_as_string == NULL) {
+        VLOG_INFO("failed to dump record");
+    }
+    VLOG_INFO("DDlog record: %s", record_as_string);
+    ddlog_string_free(record_as_string);
+
+    return true;
+}
+
+void print_deltas_callback(uintptr_t arg, table_id table, const ddlog_record *rec, ssize_t weight)
+{
+    (void) arg;
+    (void) weight;
+    (void) table;
+
+    char *record_as_string = ddlog_dump_record(rec);
+    if (record_as_string == NULL) {
+        VLOG_INFO("failed to dump delta");
+    }
+    VLOG_INFO("DDlog delta: %s", record_as_string);
+    ddlog_string_free(record_as_string);
+}
+
+void init_ddlog(void) {
+    ddlog_prog_global = ddlog_run(1, true, NULL, NULL);
+    if (!ddlog_prog_global) {
+        ovs_fatal(0, "Ddlog instance could not be created");
+    }
+}
+
+void stop_ddlog(void) {
+    ddlog_stop(ddlog_prog_global);
+}

--- a/controller/ddlog.h
+++ b/controller/ddlog.h
@@ -1,0 +1,20 @@
+#ifndef OVN_DDLOG_H
+#define OVN_DDLOG_H 1
+
+#include <stddef.h>
+
+#include "util.h"
+#include "controller/ovn_controller_ddlog/ddlog.h"
+
+#define DDLOG_PROG  (ddlog_prog_global)
+
+// the ddlog instance for ovn-controller, initialized in ovn-controller main()
+ddlog_prog ddlog_prog_global;
+
+void init_ddlog(void);
+void stop_ddlog(void);
+
+bool print_records_callback(uintptr_t arg, const ddlog_record *rec, ssize_t weight);
+void print_deltas_callback(uintptr_t arg, table_id table, const ddlog_record *rec, ssize_t weight);
+
+#endif

--- a/controller/helper.dl
+++ b/controller/helper.dl
@@ -1,0 +1,1 @@
+extern function expr_references(__match : string) : (Set<string>, Set<string>)

--- a/controller/helper.rs
+++ b/controller/helper.rs
@@ -1,0 +1,84 @@
+use ::std::ffi;
+use ::std::ptr;
+use ::std::os::raw;
+use ::libc;
+
+#[repr(C)] // from ovs/include/openvswitch/hmap.h
+pub struct hmap_node_c {
+    hash: libc::size_t,
+    next: *mut hmap_node_c
+}
+
+#[repr(C)] // from ovs/include/openvswitch/hmap.h
+pub struct hmap_c {
+    buckets: *mut *mut hmap_node_c,
+    one: *mut hmap_node_c,
+    mask: libc::size_t,
+    n: libc::size_t
+}
+
+#[repr(C)] // from ovs/lib/sset.h
+pub struct sset_c {
+    map: hmap_c
+}
+
+mod ovn_c {
+    use ::std::os::raw;
+    use super::sset_c;
+
+    #[link(name = "ovn")]
+    extern "C" {
+        // from lib/expr.c
+        pub fn expr_references_from_string(s: *const raw::c_char,addr_sets: *mut sset_c, port_groups: *mut sset_c);
+        pub fn sset_first(s: *const sset_c) -> *const raw::c_char;
+        pub fn sset_next(s: *const sset_c, name: *const raw::c_char) -> *const raw::c_char;
+    }
+
+}
+    
+// Wrapper around OVS function expr_references_from_string, that parses the match string and returns
+// sets of address_sets and port_groups
+pub fn expr_references(__match : &String) -> ddlog_std::tuple2<ddlog_std::Set<String>, ddlog_std::Set<String>> {
+    let mut res_as: ddlog_std::Set<String> = ddlog_std::Set::new();
+    let mut res_pg: ddlog_std::Set<String> = ddlog_std::Set::new();
+    unsafe {
+        let mut x = hmap_c {
+            buckets: ptr::null_mut(),
+            one: ptr::null_mut(),
+            mask: 0 as libc::size_t,
+            n: 0 as libc::size_t
+        };
+        x.buckets = &mut x.one;
+        let mut addr_sets = sset_c {
+            map: x
+        };
+
+        let mut pg = hmap_c {
+            buckets: ptr::null_mut(),
+            one: ptr::null_mut(),
+            mask: 0 as libc::size_t,
+            n: 0 as libc::size_t
+        };
+        pg.buckets = &mut pg.one;
+        let mut port_groups = sset_c {
+            map: pg
+        };
+        ovn_c::expr_references_from_string(ffi::CString::new(__match.as_str()).unwrap().as_ptr(), &mut addr_sets as *mut sset_c, &mut port_groups as *mut sset_c);
+
+        // Now go through addr_sets and add to res_as
+        let mut ptr = ovn_c::sset_first(&addr_sets);
+        while (ptr != ptr::null()) {
+            res_as.insert(ffi::CStr::from_ptr(ptr).to_owned().into_string().unwrap());
+
+            ptr = ovn_c::sset_next(&addr_sets, ptr);
+        }
+        // Now go through port_groups and add to res_pg
+        ptr = ovn_c::sset_first(&port_groups);
+        while (ptr != ptr::null()) {
+            res_pg.insert(ffi::CStr::from_ptr(ptr).to_owned().into_string().unwrap());
+
+            ptr = ovn_c::sset_next(&port_groups, ptr);
+        }
+    }
+    ddlog_std::tuple2(res_as, res_pg)
+}

--- a/controller/lflow.c
+++ b/controller/lflow.c
@@ -370,7 +370,7 @@ lflow_handle_changed_flows(struct lflow_ctx_in *l_ctx_in,
     table_id input_table;
     table_id output_table;
     const char *input_relation = "OVN_Southbound::Logical_Flow";
-    const char *output_relation = "OVNFlows";
+    const char *output_relation = "Logical_Flow_Dependencies";
 
     input_table = ddlog_get_table_id(DDLOG_PROG, input_relation);
     if (input_table == -1) {
@@ -484,9 +484,6 @@ lflow_handle_changed_flows(struct lflow_ctx_in *l_ctx_in,
             }
 
             ddlog_delta_enumerate(changes, &print_deltas_callback, (uintptr_t)(void*)(NULL));
-
-            VLOG_INFO("ddlog about to check if OVNFlows has anything..");
-            ddlog_dump_table(DDLOG_PROG, output_table, &print_records_callback, (uintptr_t)(void*)(NULL));
 
             free(struct_args);
             /*** End DDlog test code ***/

--- a/controller/ovn-controller.c
+++ b/controller/ovn-controller.c
@@ -2564,13 +2564,17 @@ check_northd_version(struct ovsdb_idl *ovs_idl, struct ovsdb_idl *ovnsb_idl,
     return true;
 }
 
-static bool print_records_callback(uintptr_t arg, const ddlog_record *rec, ssize_t weight) {
-    VLOG_INFO("Printing DDlog records\n");
+static bool print_records_callback(uintptr_t arg, const ddlog_record *rec, ssize_t weight)
+{
+    (void) arg;
+    (void) weight;
+
+    VLOG_INFO("Printing DDlog records");
     char *record_as_string = ddlog_dump_record(rec);
     if (record_as_string == NULL) {
-        VLOG_INFO(stderr, "failed to dump record\n");
+        VLOG_INFO("failed to dump record");
     }
-    VLOG_INFO("DDlog record: %s\n", record_as_string);
+    VLOG_INFO("DDlog record: %s", record_as_string);
     ddlog_string_free(record_as_string);
 
     return true;
@@ -2748,12 +2752,14 @@ main(int argc, char *argv[])
     }
 
     input_table = ddlog_get_table_id(prog, input_relation);
-    if (input_table == -1)
-        VLOG_INFO(" ddlog_get_table_id returned -1 for %s, %d\n", input_relation, input_table);
+    if (input_table == -1) {
+        VLOG_INFO("ddlog_get_table_id returned -1 for %s, %ld", input_relation, input_table);
+    }
 
     output_table  = ddlog_get_table_id(prog, output_relation);
-    if (output_table == -1)
-        VLOG_INFO("ddlog_get_table_id returned -1 for %s, %d\n", output_relation, output_table);
+    if (output_table == -1) {
+        VLOG_INFO("ddlog_get_table_id returned -1 for %s, %ld", output_relation, output_table);
+    }
 
     /* Prepare the record to be inserted to OVN_Southbound::Port_Group */
     ddlog_record **struct_args;
@@ -2771,19 +2777,23 @@ main(int argc, char *argv[])
     ddlog_record *new_record = ddlog_struct(input_relation, struct_args, 3);
     /* Finished prepared record */
 
-    if (ddlog_transaction_start(prog) < 0)
-        VLOG_INFO("ddlog failed to start transaction\n");
+    if (ddlog_transaction_start(prog) < 0) {
+        VLOG_INFO("ddlog failed to start transaction");
+    }
 
     ddlog_cmd *cmd = ddlog_insert_cmd(input_table, new_record);
-    if (cmd == NULL)
-        VLOG_INFO("ddlog failed to create insert cmd\n");
+    if (cmd == NULL) {
+        VLOG_INFO("ddlog failed to create insert cmd");
+    }
 
-    if (ddlog_apply_updates(prog, &cmd, 1) < 0)
-        VLOG_INFO("ddlog failed to apply updates\n");
+    if (ddlog_apply_updates(prog, &cmd, 1) < 0) {
+        VLOG_INFO("ddlog failed to apply updates");
+    }
 
     ddlog_delta *changes = ddlog_transaction_commit_dump_changes(prog);
-    if (changes == NULL)
-        VLOG_INFO("ddlog failed to commit transaction\n");
+    if (changes == NULL) {
+        VLOG_INFO("ddlog failed to commit transaction");
+    }
 
     ddlog_dump_table(prog, output_table, &print_records_callback, (uintptr_t)(void*)(NULL));
 

--- a/controller/ovn_controller.dl
+++ b/controller/ovn_controller.dl
@@ -1,4 +1,12 @@
 import OVN_Southbound as sb
 import OVS
+import ovsdb
 
 // Insert something useful here.
+
+// For now use some identity table so we can write the boilerpate.
+// Eventually, we need to create an output relation representing the desired_flow struct,
+// which is part of the desired_flow_table updated in ovn-controller.c
+output relation PortGroupSubset(_uuid : uuid, name: string)
+
+PortGroupSubset(_uuid, name) :- sb::Port_Group(_uuid, name, _).

--- a/controller/ovn_controller.dl
+++ b/controller/ovn_controller.dl
@@ -5,8 +5,8 @@ import ovsdb
 // Insert something useful here.
 
 // For now use some identity table so we can write the boilerpate.
-// Eventually, we need to create an output relation representing the desired_flow struct,
-// which is part of the desired_flow_table updated in ovn-controller.c
-output relation PortGroupSubset(_uuid : uuid, name: string)
+// Flow is match and actions
+output relation OVNFlows(_uuid : uuid, flow: string)
 
-PortGroupSubset(_uuid, name) :- sb::Port_Group(_uuid, name, _).
+OVNFlows(_uuid, flow) :- sb::Logical_Flow(_uuid,_,_,_,_,_,flow, _,_).
+

--- a/controller/ovn_controller.dl
+++ b/controller/ovn_controller.dl
@@ -1,12 +1,15 @@
 import OVN_Southbound as sb
 import OVS
 import ovsdb
+import helper
 
-// Insert something useful here.
-
-// For now use some identity table so we can write the boilerpate.
 // Flow is match and actions
-output relation OVNFlows(_uuid : uuid, flow: string)
+output relation Logical_Flow_Dependencies(
+    flow : sb::Logical_Flow,
+    address_sets: Set<string>,
+    port_groups: Set<string>
+)
 
-OVNFlows(_uuid, flow) :- sb::Logical_Flow(_uuid,_,_,_,_,_,flow, _,_).
-
+Logical_Flow_Dependencies(flow, addr_set, pg) :- 
+    sb::Logical_Flow[flow],
+    (var addr_set, var pg) = expr_references(flow.__match).


### PR DESCRIPTION
Opening a permanent PR to keep track of our ovn-controller changes.

This initial commit creates a dummy output relation and populates it programmatically.
Still todo:
- Create correct output relations
- Create adapters that populate DDlog whenever diffs are made to OVN_Southbound database (perhaps port from northd)